### PR TITLE
Update hash function to ensure that query is a string before hashing

### DIFF
--- a/lib/CreateEntityQuery.js
+++ b/lib/CreateEntityQuery.js
@@ -6,6 +6,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
 exports.default = entityQuery;
 
 var _QueryConnector = require('./QueryConnector');
@@ -13,6 +15,11 @@ var _QueryConnector = require('./QueryConnector');
 var _EntitySelector = require('./EntitySelector');
 
 function hash(query) {
+    if ((typeof query === 'undefined' ? 'undefined' : _typeof(query)) !== 'object' && typeof query !== 'string') {
+        throw new TypeError('Invalid query type');
+    }
+
+    query = JSON.stringify(query);
     var hash = 0;
     var i;
     var chr;

--- a/src/CreateEntityQuery.js
+++ b/src/CreateEntityQuery.js
@@ -2,6 +2,11 @@ import {connectWithQuery} from './QueryConnector';
 import {selectEntity} from './EntitySelector';
 
 function hash(query) {
+    if(typeof query !== 'object' && typeof query !== 'string') {
+        throw new TypeError('Invalid query type');
+    }
+
+    query = JSON.stringify(query);
     var hash = 0
     var i;
     var chr;


### PR DESCRIPTION
I think this should be a robust enough check while maintaining backwards compatibility with just passing a query string.

@allanhortle whaddya reckon?