### PR TITLE
Feature/merge more shallowly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 node_modules
 .nyc_output
 tags
+*.DS_Store

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "nyc ava",
+    "ava": "ava",
     "build": "rm -rf lib; BABEL_ENV=build babel src -d lib",
     "watch": "BABEL_ENV=build babel src -d lib --watch",
     "example": "NODE_ENV=development node example/index",

--- a/src/CreateEntityReducer.js
+++ b/src/CreateEntityReducer.js
@@ -1,26 +1,11 @@
 import {fromJS, Map, Iterable} from 'immutable';
 import {denormalize} from 'denormalizr';
 import {normalize} from 'normalizr';
-
-
+import DetermineReviverType from './utils/DetermineReviverType';
 
 function defaultConstructor(key, value) {
     return value;
 }
-
-function determineReviverType(constructor, schemaKey) {
-    return (key, value) => {
-        // Check if the value is an array or object and convert to that for them.
-        var isIndexed = Iterable.isIndexed(value);
-        var returnValue = isIndexed ? value.toList() : value.toMap();
-
-        // the key from the schema is used if key is undefined
-        // this is only the case if we are at the top level of our payload
-        // that way the reviver gets knowlege of what type of schema we are using
-        return constructor(key || schemaKey, returnValue);
-    }
-}
-
 
 /**
  * Returns a reducer that normalizes data based on the [normalizr] schemas provided. When an action is fired, if the type matches one provied in `schemaMap` the payload is normalized based off the given schema.
@@ -54,7 +39,7 @@ export function createEntityReducer(schemaMap, constructor = defaultConstructor)
 
     // Return our constructed reducer
     return function EntityReducer(state = initialState, {type, payload, meta}) {
-        var {
+        const {
             schema = schemaMap[type],
             resultKey = type,
             resultResetOnFetch,
@@ -74,16 +59,13 @@ export function createEntityReducer(schemaMap, constructor = defaultConstructor)
 
         if(schema && payload && /_RECEIVE$/g.test(type)) {
             // revive data from raw payload
-            var reducedData = fromJS(payload, determineReviverType(constructor, schema._key)).toJS();
+            const reducedData = fromJS(payload, DetermineReviverType(constructor, schema._key)).toJS();
             // normalize using proved schema
-            var {result, entities} = fromJS(normalize(reducedData, schema)).toObject();
-
-            // var resultData = (schema._key) ? Map().set(schema._key, result) : result;
-            var resultData = result;
+            const {result, entities} = fromJS(normalize(reducedData, schema)).toObject();
 
             return state
                 // set results
-                .setIn(['_result', resultKey], resultData)
+                .setIn(['_result', resultKey], result)
                 // merge entities
                 .mergeDeep(entities);
 

--- a/src/CreateEntityReducer.js
+++ b/src/CreateEntityReducer.js
@@ -66,8 +66,10 @@ export function createEntityReducer(schemaMap, constructor = defaultConstructor)
             return state
                 // set results
                 .setIn(['_result', resultKey], result)
-                // merge entities
-                .mergeDeep(entities);
+                // merge entities only two layers deep
+                // merges all entity types to state, and merged all entities into each entity type
+                // but will not merge the contents of entities themselves
+                .mergeWith((prev, next) => prev.merge(next), entities);
 
         }
 

--- a/src/__tests__/CreateEntityReducer-test.js
+++ b/src/__tests__/CreateEntityReducer-test.js
@@ -1,0 +1,265 @@
+import test from 'ava';
+import {createEntityReducer} from '../CreateEntityReducer';
+import {Schema, arrayOf} from 'normalizr';
+import {is, fromJS, Map} from 'immutable';
+
+//
+// Schemas
+//
+
+
+var SubredditSchema = new Schema('subreddit', {idAttribute: 'fullnameId'});
+var AuthorSchema = new Schema('author', {idAttribute: 'fullnameId'});
+var TopListingSchema = new Schema('topListings', {idAttribute: 'fullnameId'});
+
+TopListingSchema.define({
+    author: AuthorSchema
+});
+
+SubredditSchema.define({
+    topListings: arrayOf(TopListingSchema)
+});
+
+const EntitySchema = {
+    subreddit: SubredditSchema
+}
+
+test('CreateEntityReducer', tt => {
+
+    const schemaMap = {
+        mainSchema: EntitySchema,
+        TEST_RECEIVE: EntitySchema
+    };
+
+    const EntityReducer = createEntityReducer(schemaMap, (key, value) => value);
+
+    const exampleAction = {
+        type: "myType"
+    };
+
+    tt.true(
+        is(
+            EntityReducer(undefined, exampleAction).get('_schema'),
+            Map(schemaMap)
+        ),
+        'Immutable version of schema is returned under _schema when reducer is called with no existing state'
+    );
+
+    tt.true(
+        is(
+            EntityReducer(undefined, exampleAction).get('_result'),
+            Map()
+        ),
+        '_result is empty  when reducer is called with no existing state'
+    );
+
+    tt.true(
+        EntityReducer(undefined, {type: 'TEST_FETCH'})
+            .getIn(['_requestState', 'TEST_FETCH', 'fetch']),
+        '_requestState.fetch is true when action type ends with _FETCH'
+    );
+
+    tt.false(
+        EntityReducer(undefined, exampleAction)
+            .getIn(['_requestState', 'myType', 'fetch']),
+        '_requestState.fetch is false when action type does not end with _FETCH'
+    );
+
+    tt.is(
+        EntityReducer(undefined, {type: 'TEST_ERROR', payload: 'errorPayload'})
+            .getIn(['_requestState', 'TEST_ERROR', 'error']),
+        'errorPayload',
+        '_requestState.error equals payload when action type ends with _ERROR'
+    );
+
+    tt.is(
+        EntityReducer(undefined, exampleAction)
+            .getIn(['_requestState', 'myType', 'error']),
+        null,
+        '_requestState.error equals is null when action type does not end with _ERROR'
+    );
+
+    const exampleState = fromJS({
+        thing: {
+            abc: '123'
+        }
+    });
+
+    tt.true(
+        is(
+            EntityReducer(exampleState, exampleAction).get('thing'),
+            fromJS({abc: '123'})
+        ),
+        'data on state is unchanged when not receiving data'
+    );
+
+    const exampleStateWithResults = fromJS({
+        thing: {
+            abc: '123'
+        },
+        _result: {
+            TEST_FETCH: [
+                'xyz'
+            ],
+            TEST_OTHER_FETCH: [
+                'xyz'
+            ]
+        }
+    });
+
+    tt.true(
+        is(
+            EntityReducer(exampleStateWithResults, exampleAction).get('_result'),
+            exampleStateWithResults.get('_result')
+        ),
+        'state._result is unchanged when not receiving data'
+    );
+
+    tt.true(
+        is(
+            EntityReducer(exampleStateWithResults, {type: 'TEST_FETCH'}).get('_result'),
+            exampleStateWithResults.get('_result').delete('TEST_FETCH')
+        ),
+        'state._result.TYPE is deleted when TYPE is fetched'
+    );
+
+    const exampleActionNoResultReset = {
+        type: 'TEST_FETCH',
+        meta: {
+            resultResetOnFetch: false
+        }
+    };
+
+    tt.true(
+        is(
+            EntityReducer(exampleStateWithResults, exampleActionNoResultReset).get('_result'),
+            exampleStateWithResults.get('_result')
+        ),
+        'state._result.TYPE is unchanged when a type is fetched AND meta.resultResetOnFetch is true'
+    );
+
+    const examplePayload = {
+        subreddit: {
+            name: "MechanicalKeyboards",
+            fullnameId: "MK",
+            topListings: [
+                {
+                    "fullnameId": "CT",
+                    "title": "Cool title"
+                },
+                {
+                    "fullnameId": "NT",
+                    "title": "Nice title"
+                }
+            ]
+        }
+    };
+
+    const exampleReceiveAction = {
+        type: 'TEST_RECEIVE',
+        payload: examplePayload
+    };
+
+    tt.is(
+        EntityReducer(exampleState, exampleReceiveAction).getIn(['_result', 'TEST_RECEIVE', 'subreddit']),
+        'MK',
+        'Normalized results are stored in state under _result.ACTIONNAME.KEY'
+    );
+
+    tt.true(
+        is(
+            EntityReducer(exampleState, exampleReceiveAction).getIn(['subreddit', 'MK']).delete('topListings'),
+            fromJS(examplePayload.subreddit).delete('topListings')
+        ),
+        'Normalized entities are stored in state under ENTITYNAME.ID'
+    );
+
+    tt.true(
+        is(
+            EntityReducer(exampleState, exampleReceiveAction).getIn(['topListings', 'NT']),
+            fromJS(examplePayload.subreddit.topListings[1])
+        ),
+        'Normalized nested entities are stored in state under ENTITYNAME.ID'
+    );
+
+    const mergeExamplePayloadOne = {
+        subreddit: {
+            name: "MechanicalKeyboards",
+            code: "123",
+            fullnameId: "MK",
+            topListings: [
+                {
+                    "fullnameId": "CT",
+                    "title": "Cool title"
+                },
+                {
+                    "fullnameId": "NT",
+                    "title": "Nice title"
+                }
+            ]
+        }
+    };
+
+    const mergeExampleReceiveActionOne = {
+        type: 'TEST_RECEIVE',
+        payload: mergeExamplePayloadOne
+    };
+
+    const mergeExamplePayloadTwo = {
+        subreddit: {
+            name: "MechanicalKeyboards!",
+            fullnameId: "MK",
+            topListings: [
+                {
+                    "fullnameId": "NT",
+                    "title": "Nice title!"
+                },
+                {
+                    "fullnameId": "GL",
+                    "title": "Good luck"
+                }
+            ]
+        }
+    };
+
+    const mergeExampleReceiveActionTwo = {
+        type: 'TEST_RECEIVE',
+        payload: mergeExamplePayloadTwo
+    };
+
+    const mergeStateOne = EntityReducer(exampleState, mergeExampleReceiveActionOne);
+    const mergeStateTwo = EntityReducer(mergeStateOne, mergeExampleReceiveActionTwo);
+
+    tt.true(
+        is(
+            mergeStateTwo.getIn(['subreddit', 'MK']).delete('topListings'),
+            fromJS(mergeExamplePayloadTwo.subreddit).delete('topListings')
+        ),
+        'Receiving updated info for an entity will replace entity data'
+    );
+
+    tt.true(
+        is(
+            mergeStateTwo.getIn(['topListings', 'NT']),
+            fromJS(mergeExamplePayloadTwo.subreddit.topListings[0])
+        ),
+        'Receiving updated info for an entity will replace nested entity data'
+    );
+
+    tt.true(
+        is(
+            mergeStateTwo.getIn(['topListings', 'CT']),
+            fromJS(mergeExamplePayloadOne.subreddit.topListings[0])
+        ),
+        'Once an entity is received, its entity data is retained even if subsequent received entities dont contain it'
+    );
+
+    tt.true(
+        is(
+            mergeStateTwo.getIn(['topListings', 'GL']),
+            fromJS(mergeExamplePayloadTwo.subreddit.topListings[1])
+        ),
+        'Newly received nested entites are merged into their entity container'
+    );
+
+});

--- a/src/utils/DetermineReviverType.js
+++ b/src/utils/DetermineReviverType.js
@@ -1,0 +1,14 @@
+import {Iterable} from 'immutable';
+
+export default function DetermineReviverType(constructor, schemaKey) {
+    return (key, value) => {
+        // Check if the value is an array or object and convert to that for them.
+        const isIndexed = Iterable.isIndexed(value);
+        const returnValue = isIndexed ? value.toList() : value.toMap();
+
+        // the key from the schema is used if key is undefined
+        // this is only the case if we are at the top level of our payload
+        // that way the reviver gets knowlege of what type of schema we are using
+        return constructor(key || schemaKey, returnValue);
+    }
+}

--- a/src/utils/__tests__/DetermineReviverType-test.js
+++ b/src/utils/__tests__/DetermineReviverType-test.js
@@ -1,0 +1,75 @@
+import test from 'ava';
+import DetermineReviverType from '../DetermineReviverType';
+import {Schema, arrayOf} from 'normalizr';
+import {is, fromJS, Map} from 'immutable';
+
+//
+// Schemas
+//
+
+
+var SubredditSchema = new Schema('subreddit', {idAttribute: 'fullnameId'});
+var AuthorSchema = new Schema('author', {idAttribute: 'fullnameId'});
+var TopListingSchema = new Schema('topListings', {idAttribute: 'fullnameId'});
+
+TopListingSchema.define({
+    author: AuthorSchema
+});
+
+SubredditSchema.define({
+    topListings: arrayOf(TopListingSchema)
+});
+
+const EntitySchema = {
+    subreddit: SubredditSchema
+}
+
+test('DetermineReviverType', tt => {
+
+    const constructor = (key, value) => Map({key, value});
+    const schemaKey = 'mySchemaKey';
+    const reviver = DetermineReviverType(constructor, schemaKey);
+
+    const exampleMap = fromJS({abc: 123});
+    const exampleList = fromJS([1,2,3]);
+
+    tt.true(
+        is(
+            reviver('?', exampleMap).get('value'),
+            exampleMap
+        ),
+        'revivier is transparent to Maps'
+    );
+
+    tt.true(
+        is(
+            reviver('?', exampleList).get('value'),
+            exampleList
+        ),
+        'revivier is transparent to Lists'
+    );
+
+    tt.true(
+        is(
+            reviver('?', exampleMap).get('key'),
+            '?'
+        ),
+        'key supplied is returned even when schemaKey is provided'
+    );
+
+    tt.true(
+        is(
+            reviver("", exampleMap).get('key'),
+            'mySchemaKey'
+        ),
+        'returned key is schemaKey when no key is provided'
+    );
+
+    tt.true(
+        is(
+            DetermineReviverType((key, value) => value)('?', exampleMap),
+            exampleMap
+        ),
+        'reviviers output is passed through constructor'
+    );
+});


### PR DESCRIPTION
- Added full set of `CreateEntityReducer` tests
- Moved `DetermineRevivertype` out of `CreateEntityReducer` and wrote tests for it
- Fixed merging bug, no longer merges contents of individual entities (behaviour like this is expected and validated by the current set of `CreateEntityReducer` tests)